### PR TITLE
Fixing of minor but annoying errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Inspired by https://github.com/krisajenkins/yesql
 <plugin>
     <groupId>com.yesql4j</groupId>
     <artifactId>yesql4j-maven-plugin</artifactId>
-    <version>0.1.6-beta</version>
+    <version>0.1.7-beta</version>
     <configuration>
         <generator>SPRING</generator>
     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.yesql4j</groupId>
     <artifactId>yesqlj4-root</artifactId>
     <packaging>pom</packaging>
-    <version>0.1.6-beta</version>
+    <version>0.1.7-beta</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <url>https://yesql4j.com/</url>

--- a/yesql4j-maven-plugin/pom.xml
+++ b/yesql4j-maven-plugin/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <artifactId>yesqlj4-root</artifactId>
         <groupId>com.yesql4j</groupId>
-        <version>0.1.6-beta</version>
+        <version>0.1.7-beta</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <version>0.1.6-beta</version>
+    <version>0.1.7-beta</version>
 
     <artifactId>yesql4j-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>

--- a/yesql4j-maven-plugin/src/main/resources/spring.tpl
+++ b/yesql4j-maven-plugin/src/main/resources/spring.tpl
@@ -2,7 +2,6 @@
 package {{packageName}};
 {{/if}}
 
-import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.lang.NonNull;
 import org.springframework.jdbc.core.RowMapper;
@@ -10,6 +9,7 @@ import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Component;
 import java.sql.PreparedStatement;
+import java.sql.Statement;
 import java.util.List;
 import java.util.Arrays;
 import com.yesql4j.spring.InParameters;
@@ -35,8 +35,8 @@ public final class {{className}} {
         }
     }{{else}}
     @NonNull
-    public <T> Lst<T> {{name}}(RowMapper<T> rowMapper) {
-        return jdbcTemplate.query(pool, "{{query}}", rowMapper);
+    public <T> List<T> {{name}}(RowMapper<T> rowMapper) {
+        return jdbcTemplate.query("{{query}}", rowMapper);
     }{{/if}}
 {{/each}}
 {{#each updates}}{{#if hasParams}}
@@ -61,7 +61,7 @@ public final class {{className}} {
             List<Object> updatedParams = params;
             if (InParameters.hasListParam(params)) {
                 String updatedQuery = InParameters.addListParams("{{query}}", Arrays.asList({{paramsIndexes}}), params);
-                ps = connection.prepareStatement(updatedQuery);
+                ps = connection.prepareStatement(updatedQuery, Statement.RETURN_GENERATED_KEYS);
                 updatedParams = InParameters.flattenParams(params);
             }else {
                 ps = connection.prepareStatement("{{query}}");

--- a/yesql4j-spring/pom.xml
+++ b/yesql4j-spring/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <artifactId>yesqlj4-root</artifactId>
         <groupId>com.yesql4j</groupId>
-        <version>0.1.6-beta</version>
+        <version>0.1.7-beta</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>yesql4j-spring</artifactId>
-    <version>0.1.6-beta</version>
+    <version>0.1.7-beta</version>
 
 </project>

--- a/yesql4j-vertx-mysql-reactor/README.md
+++ b/yesql4j-vertx-mysql-reactor/README.md
@@ -2,7 +2,7 @@
 Update project properties:
 ```$xml
 <properties>
-  <yesql4j.version>0.1.6-beta</yesql4j.version>
+  <yesql4j.version>0.1.7-beta</yesql4j.version>
 </properties>
 ```
 

--- a/yesql4j-vertx-mysql-reactor/pom.xml
+++ b/yesql4j-vertx-mysql-reactor/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <artifactId>yesqlj4-root</artifactId>
         <groupId>com.yesql4j</groupId>
-        <version>0.1.6-beta</version>
+        <version>0.1.7-beta</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <version>0.1.6-beta</version>
+    <version>0.1.7-beta</version>
 
     <artifactId>yesql4j-vertx-mysql-reactor</artifactId>
 


### PR DESCRIPTION
- Generated queries for insert didn't pass the `Statement.RETURN_GENERATED_KEYS` flag while preparation of statement and so MySQL returned errors on attempt to fetch the keys
```
Caused by: java.sql.SQLException: Generated keys not requested. You need to specify Statement.RETURN_GENERATED_KEYS to Statement.executeUpdate(), Statement.executeLargeUpdate() or Connection.prepareStatement().
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:129)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:97)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:89)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:63)
	at com.mysql.cj.jdbc.StatementImpl.getGeneratedKeys(StatementImpl.java:1376)
	at com.zaxxer.hikari.pool.ProxyStatement.getGeneratedKeys(ProxyStatement.java:230)
	at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.getGeneratedKeys(HikariProxyPreparedStatement.java)
	at org.springframework.jdbc.core.JdbcTemplate.lambda$update$1(JdbcTemplate.java:897)
	at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:617)
	... 19 common frames omitted
``` 

- If query didn't have parameters - some erroneous DAO was generated. There was TYPO in word `List` and some unknown `pool` variable was used.
- Fix of imports - `org.springframework.dao.DataAccessException` had separate import statement, but there were no usages of this exception